### PR TITLE
Sethome command (and possibly other modules using Location.getFactionClaim()) fix. 

### DIFF
--- a/improved-factions-base/src/main/kotlin/io/github/toberocat/improvedfactions/claims/FactionClaimHandler.kt
+++ b/improved-factions-base/src/main/kotlin/io/github/toberocat/improvedfactions/claims/FactionClaimHandler.kt
@@ -9,9 +9,7 @@ import kotlin.math.ceil
 import kotlin.math.floor
 
 fun Block.getFactionClaim(): FactionClaim? = location.getFactionClaim()
-fun Location.getFactionClaim(): FactionClaim? = world?.name?.let {
-    getFactionClaim((x / 16.0).largerValueRound(), (z / 16.0).largerValueRound(), it)
-}
+fun Location.getFactionClaim(): FactionClaim? = chunk.getFactionClaim()
 fun Chunk.getFactionClaim() = getFactionClaim(x, z, world.name)
 
 fun getFactionClaim(x: Int, z: Int, worldName: String) = FactionClaim.find {


### PR DESCRIPTION
Fixed Location.getFactionClaim() returning the wrong chunk information causing the /f sethome command to not work.

Related to issue #133 