### PR TITLE
Fix zone protections for players not in a faction

### DIFF
--- a/improved-factions-base/src/main/kotlin/io/github/toberocat/improvedfactions/listeners/claim/ProtectionListener.kt
+++ b/improved-factions-base/src/main/kotlin/io/github/toberocat/improvedfactions/listeners/claim/ProtectionListener.kt
@@ -37,7 +37,7 @@ abstract class ProtectionListener(protected val zoneType: String,
 
         val claimedFaction = claim.factionId
         val playerFaction = player.factionUser().factionId
-        if (claimedFaction == playerFaction)
+        if (claimedFaction == playerFaction && playerFaction != noFactionId)
             return@loggedTransaction
 
         if (claimClusters.getCluster(Position(chunk.x, chunk.z, claim.world, claimedFaction))


### PR DESCRIPTION
The plugin assumed that because the claimed faction and player faction were equal, they were the same faction. Really, they were both set to noFactionId

Closes #159 