### PR TITLE
Update pom.xml

### DIFF
--- a/improved-factions-base/pom.xml
+++ b/improved-factions-base/pom.xml
@@ -122,6 +122,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
                     <source>16</source>
                     <target>16</target>
@@ -195,9 +196,9 @@
                         </goals>
                         <configuration>
                             <file>${project.build.directory}/${project.build.finalName}.jar</file>
-                            <groupId>${groupId}</groupId>
-                            <artifactId>${artifactId}</artifactId>
-                            <version>${version}</version>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>${project.version}</version>
                             <packaging>${packaging}</packaging>
                         </configuration>
                     </execution>


### PR DESCRIPTION
- Updated deprecated plugin configuration (groupId -> project.groupId), etc.
to suppress maven compile warnings