### PR TITLE
Block bucket from being used in other factions

### DIFF
--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/listeners/claim/ClaimBlockInteractListener.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/listeners/claim/ClaimBlockInteractListener.kt
@@ -2,6 +2,8 @@ package io.github.toberocat.improvedfactions.listeners.claim
 
 import org.bukkit.event.EventHandler
 import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit.Material
 
 class ClaimBlockInteractListener(zoneType: String) : ProtectionListener(
     zoneType,
@@ -11,8 +13,19 @@ class ClaimBlockInteractListener(zoneType: String) : ProtectionListener(
 
     @EventHandler
     fun interact(event: PlayerInteractEvent) {
-        if (event.clickedBlock?.type?.isInteractable == false)
+        val mainHand = event.player.inventory.itemInMainHand
+        val offHand = event.player.inventory.itemInOffHand
+
+        if (event.clickedBlock?.type?.isInteractable == false && !isBucket(mainHand) && !isBucket(offHand))
             return
+            
         protectChunk(event, event.clickedBlock, event.player)
+    }
+
+    fun isBucket(item: ItemStack?): Boolean {
+        if (item == null) return false
+        if (item.type == Material.BUCKET || item.type.name.endsWith("_BUCKET")) return true
+
+        return false
     }
 }


### PR DESCRIPTION
Current implementation `onBucket` does not work for some reason, so we should use `interact` event instead to block.

[WorldGuard also uses `interact` event to prevent bucket uses.](https://github.com/EngineHub/WorldGuard/blob/version/7.0.x/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java#L210)